### PR TITLE
Correct camera targeting after centering object

### DIFF
--- a/Proyecto-3d/script.js
+++ b/Proyecto-3d/script.js
@@ -42,11 +42,11 @@ mtlLoader.load('16837_eye_v2_NEW.mtl', (materials) => {
     let dist = (size / 2) / Math.tan(fov / 2);
     dist *= fitOffset;
 
-    camera.position.copy(center.clone().add(new THREE.Vector3(0, 0, dist)));
+    camera.position.set(0, 0, dist);
     camera.near = dist / 100;
     camera.far = dist * 100;
     camera.updateProjectionMatrix();
-    controls.target.copy(center);
+    controls.target.set(0, 0, 0);
     controls.update();
   });
 });


### PR DESCRIPTION
## Summary
- Reset camera position and controls target to origin after model centering for correct object framing

## Testing
- `npm test` (fails: package.json missing)

------
https://chatgpt.com/codex/tasks/task_e_689a7cf2e7ec8332b13def2049a52d39